### PR TITLE
Add the next LSN to the return type of the callback action

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -18,6 +18,7 @@ main = do
   withLogicalStream settings $ \change -> do
     putStrLn "Change received!"
     print change
+    pure $ changeNextLSN change
   `catch`
   \exc -> do
     putStrLn "Something bad happened: "

--- a/src/Database/PostgreSQL/Replicant.hs
+++ b/src/Database/PostgreSQL/Replicant.hs
@@ -29,7 +29,10 @@ provide better ergonomics.
 
 module Database.PostgreSQL.Replicant
     ( withLogicalStream
+    -- * Types
     , PgSettings (..)
+    -- * Re-exports
+    , changeNextLSN
     ) where
 
 import Control.Concurrent
@@ -46,6 +49,7 @@ import Database.PostgreSQL.Replicant.Exception
 import Database.PostgreSQL.Replicant.Protocol
 import Database.PostgreSQL.Replicant.Message
 import Database.PostgreSQL.Replicant.ReplicationSlot
+import Database.PostgreSQL.Replicant.Types.Lsn
 import Database.PostgreSQL.Replicant.Util
 
 data PgSettings
@@ -82,7 +86,7 @@ pgConnectionString PgSettings {..} = B.intercalate " "
 --
 -- This function can throw exceptions in @IO@ and shut-down the
 -- socket in case of any error.
-withLogicalStream :: PgSettings -> (Change -> IO a) -> IO ()
+withLogicalStream :: PgSettings -> (Change -> IO LSN) -> IO ()
 withLogicalStream settings cb = do
   conn <- connectStart $ pgConnectionString settings
   mFd <- socket conn

--- a/src/Database/PostgreSQL/Replicant/Message.hs
+++ b/src/Database/PostgreSQL/Replicant/Message.hs
@@ -392,7 +392,10 @@ instance FromJSON WalLogData where
 data Change
   = Change
   { changeNextLSN :: LSN
+    -- ^ Return this LSN in your callback to update the stream state
+    -- in replicant
   , changeDeltas  :: [WalLogData]
+    -- ^ The list of WAL log changes in this transaction.
   }
   deriving (Eq, Generic, Show)
 


### PR DESCRIPTION
By returning the "next LSN" of the change to replicant we update the
stream state and assume the change has been committed.

Add `changeNextLSN` to Replicant export list

Also update the haddocks for the `Change` type and `Replicant` module
exports list.

Update README.md

Add information about the changes to the callback and updating the
stream state.