### PR TITLE
Add Strict pragma to all modules

### DIFF
--- a/src/Database/PostgreSQL/Replicant.hs
+++ b/src/Database/PostgreSQL/Replicant.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 {-|
 Module      : Database.PostgreSQL.Replicant
 Description : A PostgreSQL streaming replication library

--- a/src/Database/PostgreSQL/Replicant/Connection.hs
+++ b/src/Database/PostgreSQL/Replicant/Connection.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 {-
 Module : Database.PostgreSQL.Replicant.Connection
 Description : Create replication handling connections to PostgreSQL

--- a/src/Database/PostgreSQL/Replicant/Exception.hs
+++ b/src/Database/PostgreSQL/Replicant/Exception.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Database.PostgreSQL.Replicant.Exception where
 
 import Control.Exception

--- a/src/Database/PostgreSQL/Replicant/Message.hs
+++ b/src/Database/PostgreSQL/Replicant/Message.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 {-|
 Module      : Database.PostgreSQL.Replicant.Message
 Description : Streaming replication message types

--- a/src/Database/PostgreSQL/Replicant/PostgresUtils.hs
+++ b/src/Database/PostgreSQL/Replicant/PostgresUtils.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Database.PostgreSQL.Replicant.PostgresUtils where
 
 import Data.Fixed

--- a/src/Database/PostgreSQL/Replicant/Protocol.hs
+++ b/src/Database/PostgreSQL/Replicant/Protocol.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 {-|
 Module      : Database.PostgreSQL.Replicant.Protocol
 Description : Streaming replication protocol

--- a/src/Database/PostgreSQL/Replicant/ReplicationSlot.hs
+++ b/src/Database/PostgreSQL/Replicant/ReplicationSlot.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 {-|
 Module      : Database.PostgreSQL.Replicant.ReplicationSlot
 Description : Replication slot query commands

--- a/src/Database/PostgreSQL/Replicant/Serialize.hs
+++ b/src/Database/PostgreSQL/Replicant/Serialize.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Database.PostgreSQL.Replicant.Serialize where
 
 import Data.ByteString (ByteString)

--- a/src/Database/PostgreSQL/Replicant/Settings.hs
+++ b/src/Database/PostgreSQL/Replicant/Settings.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 module Database.PostgreSQL.Replicant.Settings where
 
 import Data.ByteString (ByteString)

--- a/src/Database/PostgreSQL/Replicant/State.hs
+++ b/src/Database/PostgreSQL/Replicant/State.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 {-|
 Module      : Database.PostgreSQL.Replicant.State
 Description : Internal replication stream state

--- a/src/Database/PostgreSQL/Replicant/Types/Lsn.hs
+++ b/src/Database/PostgreSQL/Replicant/Types/Lsn.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Strict #-}
+
 {-|
 Module      : Database.PostgreSQL.Replicant.Types.Lsn
 Description : Types and parsers for LSNs


### PR DESCRIPTION
In some not-terribly-scientific benchmarks it seems that there are
some leaking thunks in the library.  Adding this pragma and re-running
the benchmarks showed a drastic improvement in heap allocations.

Fixes: #17 