### PR TITLE
Replace cereal package with binary

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -37,9 +37,9 @@ library:
   - aeson
   - attoparsec
   - async
+  - binary
   - bits
   - bytestring
-  - cereal
   - containers
   - keep-alive
   - postgresql-libpq

--- a/src/Database/PostgreSQL/Replicant/Serialize.hs
+++ b/src/Database/PostgreSQL/Replicant/Serialize.hs
@@ -2,11 +2,10 @@
 
 module Database.PostgreSQL.Replicant.Serialize where
 
+import Data.Binary.Get
 import Data.ByteString (ByteString)
-import Data.Serialize
+import qualified Data.ByteString.Lazy as BL
 
--- | Consume the rest of the @Get a@ input as a ByteString
+-- | Consume the rest of the @Get a@ input as a strict ByteString
 consumeByteStringToEnd :: Get ByteString
-consumeByteStringToEnd = do
-  numRemaining <- remaining
-  getByteString numRemaining
+consumeByteStringToEnd = BL.toStrict <$> getRemainingLazyByteString

--- a/src/Database/PostgreSQL/Replicant/Types/Lsn.hs
+++ b/src/Database/PostgreSQL/Replicant/Types/Lsn.hs
@@ -27,13 +27,15 @@ module Database.PostgreSQL.Replicant.Types.Lsn where
 
 import Data.Aeson
 import Data.Attoparsec.ByteString.Char8
+import Data.Binary
+import Data.Binary.Get
+import Data.Binary.Put
 import Data.Bits
 import Data.Bits.Extras
 import Data.ByteString (ByteString ())
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Lazy.Builder as Builder
 import Data.ByteString.Lazy.Builder.ASCII (word32Hex)
-import Data.Serialize
 import Data.Word
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
@@ -49,7 +51,7 @@ instance Ord LSN where
   compare (LSN l0 r0) (LSN l1 r1) =
     compare l0 l1 <> compare r0 r1
 
-instance Serialize LSN where
+instance Binary LSN where
   put = putInt64be . toInt64
   get = fromInt64 <$> getInt64be
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -68,7 +68,7 @@ extra-deps:
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor
 
-# To enable profile build, uncomment:
+# To enable profile build:
 # build:
 #   library-profiling: true
 #   executable-profiling: true

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,9 +1,10 @@
 import Test.Hspec
 
-import Data.Serialize
+import Data.Binary
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as B8
+import qualified Data.ByteString.Lazy as BL
 import Data.Word
 import GHC.Int
 
@@ -11,10 +12,10 @@ import Database.PostgreSQL.Replicant.Message
 import Database.PostgreSQL.Replicant.Settings
 import Database.PostgreSQL.Replicant.Types.Lsn
 
-examplePrimaryKeepAliveMessage :: ByteString
+examplePrimaryKeepAliveMessage :: BL.ByteString
 examplePrimaryKeepAliveMessage
-  = B.concat
-    [ (B.pack [0x6B])
+  = BL.concat
+    [ (BL.pack [0x6B])
     , (encode @LSN (fromInt64 123))
     , (encode @LSN (fromInt64 346))
     , (encode @Word8 1)
@@ -25,12 +26,22 @@ main = hspec $ do
   context "Message" $ do
     describe "PrimaryKeepAlive" $ do
       it "should decode a valid primary keep alive message" $ do
-        (decode $ examplePrimaryKeepAliveMessage)
-          `shouldBe`
-          (Right $ PrimaryKeepAlive 123 346 ShouldRespond)
+        let Right (_, _, result)
+              = decodeOrFail
+              $ examplePrimaryKeepAliveMessage
+        result `shouldBe` (PrimaryKeepAlive 123 346 ShouldRespond)
 
     describe "StandbyStatusUpdate" $ do
       it "should encode a valid standby status update message" $ do
+        let expected
+              = BL.concat
+              [ BL.pack [0x72]
+              , encode @LSN (fromInt64 213)
+              , encode @LSN (fromInt64 232)
+              , encode @LSN (fromInt64 234)
+              , encode @Int64 454
+              , encode @Word8 0
+              ]
         (encode $ StandbyStatusUpdate
          (fromInt64 213)
          (fromInt64 232)
@@ -38,52 +49,37 @@ main = hspec $ do
          454
          DoNotRespond)
           `shouldBe`
-          B.concat
-          [ B.pack [0x72]
-          , encode @LSN (fromInt64 213)
-          , encode @LSN (fromInt64 232)
-          , encode @LSN (fromInt64 234)
-          , encode @Int64 454
-          , encode @Word8 0
-          ]
+          expected
 
     describe "XLogData" $ do
       it "should encode/decode a valid xLogData message" $ do
         let msg = XLogData (fromInt64 123) (fromInt64 234) 345 (B8.pack "hello")
-        (decode . encode $ msg)
-          `shouldBe`
-          Right msg
+        (decode @XLogData . encode $ msg) `shouldBe` msg
 
     describe "HotStandbyFeedback" $ do
       it "should encode/decode a valid HotStandbyFeedback message" $ do
         let msg = HotStandbyFeedback 123 234 456
-        (decode . encode $ msg)
-          `shouldBe`
-          Right msg
+        (decode @HotStandbyFeedback . encode $ msg) `shouldBe` msg
 
     describe "WalCopyData" $ do
       it "should encode/decode an XLogData message" $ do
         let msg = XLogDataM (XLogData (fromInt64 123) (fromInt64 234) 345 (B8.pack "hello"))
-        (decode . encode $ msg)
-          `shouldBe`
-          Right msg
+        (decode @WalCopyData . encode $ msg) `shouldBe` msg
 
       it "should encode/decode a PrimaryKeepAlive message" $ do
         let msg = KeepAliveM (PrimaryKeepAlive 123 346 ShouldRespond)
-        (decode . encode $ msg)
-          `shouldBe`
-          Right msg
+        (decode @WalCopyData . encode $ msg) `shouldBe` msg
 
   context "Types" $ do
     describe "LSN" $ do
-      context "Serializable" $ do
+      context "Binary" $ do
         it "should be serializable" $ do
           let lsn = LSN 2 23
-          (decode . encode $ lsn) `shouldBe` Right lsn
+          (decode @LSN . encode $ lsn) `shouldBe` lsn
 
         it "should be equivalent to fromByteString/toByteString" $ do
           let (Right lsn) = fromByteString "16/3002D50"
-          (toByteString <$> (decode . encode @LSN $ lsn)) `shouldBe` Right "16/3002d50"
+          (toByteString $ (decode @LSN . encode @LSN $ lsn)) `shouldBe` "16/3002d50"
 
   context "Settings" $ do
     describe "pgConnectionString" $ do


### PR DESCRIPTION
`cereal` is in life support maintenance mode.  Work is being done to the `binary` package to support strict parsing with a `binary` like API which is what cereal is for.