### PR TITLE
Add ChangePayload

### DIFF
--- a/src/Database/PostgreSQL/Replicant.hs
+++ b/src/Database/PostgreSQL/Replicant.hs
@@ -31,8 +31,10 @@ module Database.PostgreSQL.Replicant
     (
     -- * Types
       Change (..)
+    , ChangePayload (..)
     , Column (..)
     , Delete (..)
+    , Information (..)
     , Insert (..)
     , Message (..)
     , PgSettings (..)
@@ -76,7 +78,7 @@ import Database.PostgreSQL.Replicant.Util
 --
 -- This function can throw exceptions in @IO@ and shut-down the
 -- socket in case of any error.
-withLogicalStream :: PgSettings -> (Change -> IO LSN) -> IO ()
+withLogicalStream :: PgSettings -> (ChangePayload -> IO (Maybe LSN)) -> IO ()
 withLogicalStream settings cb = do
   conn <- connect settings
   let updateFreq = getUpdateDelay settings


### PR DESCRIPTION
This type parses the two cases of WAL messages we receive: informational messages emitted by the Postgres function, `pg_logical_emit_message` (when emitted outside of a transaction), and change messages containing the usual transaction changes.

We can tell these message types apart because the change messages have a `nextlsn` key that we need to return to the server.  Informational messages are purely for information and are not part of the WAL log stream so they don't have an LSN.

This change will change the type of the public API and require a minor version bump.

Fixes: #28