### PR TITLE
Fix Lsn to use supported bytestring imports

### DIFF
--- a/src/Database/PostgreSQL/Replicant/Types/Lsn.hs
+++ b/src/Database/PostgreSQL/Replicant/Types/Lsn.hs
@@ -31,8 +31,7 @@ import Data.Bits
 import Data.Bits.Extras
 import Data.ByteString (ByteString ())
 import qualified Data.ByteString.Lazy as BL
-import qualified Data.ByteString.Lazy.Builder as Builder
-import Data.ByteString.Lazy.Builder.ASCII (word32Hex)
+import qualified Data.ByteString.Builder as Builder
 import Data.Serialize
 import Data.Word
 import qualified Data.Text as T
@@ -88,9 +87,9 @@ fromByteString = parseOnly lsnParser
 toByteString :: LSN -> ByteString
 toByteString (LSN filepart off) = BL.toStrict
   $ Builder.toLazyByteString
-  ( word32Hex (fromIntegral filepart)
+  ( Builder.word32Hex (fromIntegral filepart)
     <> Builder.char7 '/'
-    <> word32Hex (fromIntegral off)
+    <> Builder.word32Hex (fromIntegral off)
   )
 
 -- | Add a number of bytes to an LSN

--- a/stack-nightly-2023-08-04.yaml
+++ b/stack-nightly-2023-08-04.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-18.28
+resolver: nightly-2023-08-04
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -28,6 +28,7 @@ resolver: lts-18.28
 #   subdirs:
 #   - auto-update
 #   - wai
+
 # Dependency packages to be pulled from upstream that are not in the resolver.
 # These entries can reference officially published versions as well as
 # forks / in-progress versions pinned to a git hash. For example:


### PR DESCRIPTION
Bytestring deprecated the modules we're importing from and moved the functions elsewhere.

This change fixes the imports.

Fixes: #30